### PR TITLE
fix(sanitize): allow spaces in the filename

### DIFF
--- a/octoprint_GcodeEditor/static/js/GcodeEditor.js
+++ b/octoprint_GcodeEditor/static/js/GcodeEditor.js
@@ -302,7 +302,7 @@ $(function() {
 
         // https://github.com/foosel/OctoPrint/blob/master/src/octoprint/static/js/app/viewmodels/slicing.js#L294
         self._sanitize = function(name) {
-            return name.replace(/[^a-zA-Z0-9\-_\.\(\) ]/g, "").replace(/ /g, "_");
+            return name.replace(/[^a-zA-Z0-9\-_\.\(\) ]/g, "");
         };
 
         self.onStartupComplete = function() {


### PR DESCRIPTION
It looks like Octoprint doesn't have any issue for handling filenames with spaces. So there is no need to sanitize them.

Fixes https://github.com/ieatacid/OctoPrint-GcodeEditor/issues/25